### PR TITLE
Add null-check for empty cells

### DIFF
--- a/src/main/groovy/pl/droidsonroids/gradle/localization/SourceInfo.groovy
+++ b/src/main/groovy/pl/droidsonroids/gradle/localization/SourceInfo.groovy
@@ -50,7 +50,7 @@ class SourceInfo {
         reservedColumns.addAll(config.ignorableColumns)
 
         header.eachWithIndex { columnName, i ->
-            if (!(columnName in reservedColumns) && i != mNameIdx) {
+            if (!(columnName in reservedColumns) && i != mNameIdx && !columnName.isEmpty()) {
                 mBuilders[i] = new XMLBuilder(columnName, config, resDir, outputFileName)
             }
         }

--- a/src/main/groovy/pl/droidsonroids/gradle/localization/Utils.groovy
+++ b/src/main/groovy/pl/droidsonroids/gradle/localization/Utils.groovy
@@ -29,9 +29,11 @@ class Utils {
         if (!shouldIgnoreEmptyHeaderCell) {
             def emptyHeaderIndices = headerLine.findIndexValues { it.empty }
             allCells.eachWithIndex { String[] row, int rowIndex ->
-                emptyHeaderIndices.forEach { i ->
-                    if (i < row.length && !row[i.intValue()].empty) {
-                        throw new IllegalArgumentException("Not ignored column #$i contains empty header but non-empty cell at row #$rowIndex")
+                if (row != null) {
+                    emptyHeaderIndices.forEach { i ->
+                        if (i < row.length && !row[i.intValue()].empty) {
+                            throw new IllegalArgumentException("Not ignored column #$i contains empty header but non-empty cell at row #$rowIndex")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It sometimes happens, that a cell is empty and should be ignored. 
Currently, if there is no value in a cell, its null and thus the length property cant be accessed. 